### PR TITLE
chore: clean unusued additional function/component name code

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,6 @@ Ex.
 }
 ```
 
-#### additionalFunctionNames (Optional)
-
-Similar to [@formatjs/ts-transformer](https://formatjs.io/docs/tooling/ts-transformer#additionalfunctionnames), this allows you to specify additional function names to check besides `formatMessage`.
-
-#### additionalComponentNames (Optional)
-
-Similar to [@formatjs/ts-transformer](https://formatjs.io/docs/tooling/ts-transformer#additionalcomponentnames), this allows you to specify additional component names to check besides `FormatMessage`.
-
 #### onUndefinedMessage (Optional)
 
 Callback function for when an string ID is encountered without a corresponding entry in the translatedMessages object. In this scenario the plugin falls back to the source language.

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -34,8 +34,6 @@ describe("babel-plugin-formatjs-localized-bundle", () => {
                   "normal",
                   "mockMessages.js"
                 )),
-                additionalComponentNames: ["LocalMsg"],
-                additionalFunctionNames: ["localize"],
               },
             ],
           ],
@@ -75,8 +73,6 @@ describe("babel-plugin-formatjs-localized-bundle", () => {
                   "normal",
                   "mockMessages.js"
                 ),
-                additionalComponentNames: ["LocalMsg"],
-                additionalFunctionNames: ["localize"],
               },
             ],
           ],
@@ -139,8 +135,6 @@ describe("babel-plugin-formatjs-localized-bundle", () => {
                   "pre-compiled",
                   "mockMessages.js"
                 )),
-                additionalComponentNames: ["LocalMsg"],
-                additionalFunctionNames: ["localize"],
               },
             ],
           ],
@@ -279,8 +273,6 @@ describe("babel-plugin-formatjs-localized-bundle", () => {
                   "pre-compiled-nextjs",
                   "mockMessages.js"
                 )),
-                additionalComponentNames: ["LocalMsg"],
-                additionalFunctionNames: ["localize"],
               },
             ],
           ],

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,6 @@ module.exports = (babel, options) => {
     return {};
   }
 
-  const additionalFunctionName = options.additionalFunctionNames || [];
-  const additionalComponentNames = options.additionalComponentNames || [];
-  const functionNames = ["formatMessage", ...additionalFunctionName];
-  const componentNames = ["FormattedMessage", ...additionalComponentNames];
-
   // Messages are expected to be an object of form {[id: string]: string | AST}
   // translatedMessages can either be an object or a path to an object
   const messages =


### PR DESCRIPTION
We don't use this code anymore because we just look for defaultMessage now